### PR TITLE
updated documentation for typed json output

### DIFF
--- a/WebContent/doc/Concepts.html
+++ b/WebContent/doc/Concepts.html
@@ -313,19 +313,19 @@ Accept: application/json
 Content-Type: application/json
 
 { "actors": [
-   { "last_name": "SMITH", "first_name": "JULIANNE", "actor_id": "201",
+   { "last_name": "SMITH", "first_name": "JULIANNE", "actor_id": 201,
       "films": [
-         { "year": "2006", "title": "ACADEMY DINOSAUR", "film_id": "1" },
-         { "year": "2006", "title": "ADAPTATION HOLES", "film_id": "3" },
-         { "year": "2006", "title": "ANACONDA CONFESSIONS", "film_id": "23" }
+         { "year": 2006, "title": "ACADEMY DINOSAUR", "film_id": 1 },
+         { "year": 2006, "title": "ADAPTATION HOLES", "film_id": 3 },
+         { "year": 2006, "title": "ANACONDA CONFESSIONS", "film_id": 23 }
       ]
    },
-   { "last_name": "SMITH", "first_name": "PATRICK", "actor_id": "205",
+   { "last_name": "SMITH", "first_name": "PATRICK", "actor_id": 205,
       "films": [
-         { "year": "2006", "title": "APACHE DIVINE", "film_id": "31" },
-         { "year": "2006", "title": "BABY HALL", "film_id": "47" },
-         { "year": "2006", "title": "BULL SHAWSHANK", "film_id": "105" },
-         { "year": "2006", "title": "CHAINSAW UPTOWN", "film_id": "132" }
+         { "year": 2006, "title": "APACHE DIVINE", "film_id": 31 },
+         { "year": 2006, "title": "BABY HALL", "film_id": 47 },
+         { "year": 2006, "title": "BULL SHAWSHANK", "film_id": 105 },
+         { "year": 2006, "title": "CHAINSAW UPTOWN", "film_id": 132 }
       ]
    }   
 }

--- a/WebContent/doc/ref/ResDeletePath.html
+++ b/WebContent/doc/ref/ResDeletePath.html
@@ -116,7 +116,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "1" }</pre>
+{ "rowsAffected": 1 }</pre>
 
 <div class="text">A delete to parents and children of a one-to-many hierarchical SQL Resource:</div>
 <pre>DELETE /restsql/res/LanguageFilm/3 HTTP/1.1
@@ -126,7 +126,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "13" }</pre>
+{ "rowsAffected": 13 }</pre>
 
 <div class="text">A delete to parents of a many-to-many hierarchical SQL Resource (parent rows are deleted, and child rows are disassociated):</div>
 <pre>DELETE /restsql/res/ActorFilm/123 HTTP/1.1
@@ -136,7 +136,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "9" }</pre>
+{ "rowsAffected": 9 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResDeletePathXmlOrJson.html
+++ b/WebContent/doc/ref/ResDeletePathXmlOrJson.html
@@ -117,9 +117,9 @@ Content-Type: application/json
 Accept: application/json
 
 { "films": [
-      { "film_id": "3" },
-      { "film_id": "43" },
-      { "film_id": "67" },
+      { "film_id": 3 },
+      { "film_id": 43 },
+      { "film_id": 67 },
    ]
 }
 </pre>
@@ -127,7 +127,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 
 <div class="text">A many-to-many hierarchical SQL Resource (child rows are disassociated):</div>
 <pre>DELETE /restsql/res/ActorFilm/123 HTTP/1.1
@@ -135,9 +135,9 @@ Content-Type: application/json
 Accept: application/json
 
 { "films": [
-      { "film_id": "3" },
-      { "film_id": "43" },
-      { "film_id": "233" },
+      { "film_id": 3 },
+      { "film_id": 43 },
+      { "film_id": 233 },
    ]
 }
 </pre>
@@ -145,7 +145,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResDeleteQuery.html
+++ b/WebContent/doc/ref/ResDeleteQuery.html
@@ -117,7 +117,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 
 <div class="text">A delete to parents of a one-to-many hierarchical SQL Resource (child rows are also deleted):</div>
 <pre>DELETE /restsql/res/LanguageFilm/3 HTTP/1.1
@@ -127,7 +127,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "18" }</pre>
+{ "rowsAffected": 18 }</pre>
 
 <div class="text">A delete to parents of a many-to-many hierarchical SQL Resource (parent rows are deleted, and child rows are disassociated):</div>
 <pre>DELETE /restsql/res/ActorFilm?last_name=DENCH HTTP/1.1
@@ -137,7 +137,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "9" }</pre>
+{ "rowsAffected": 9 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResDeleteXmlOrJson.html
+++ b/WebContent/doc/ref/ResDeleteXmlOrJson.html
@@ -160,16 +160,16 @@ Content-Type: application/json
 Accept: application/json
 
 { "actors": [
-      { "actor_id": "123", "first_name": "JULIANNE", "surname": "DENCH" },
-      { "actor_id": "124", "first_name": "SCARLETT", "surname": "BENING" },
-      { "actor_id": "125", "first_name": "ALBERT", "surname": "NOLTE" }
+      { "actor_id": 123, "first_name": "JULIANNE", "surname": "DENCH" },
+      { "actor_id": 124, "first_name": "SCARLETT", "surname": "BENING" },
+      { "actor_id": 125, "first_name": "ALBERT", "surname": "NOLTE" }
    [
 }
 </pre>
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 
 <div class="text">A delete to parents and children of a one-to-many hierarchical SQL Resource:</div>
 <pre>DELETE /restsql/res/LanguageFilm HTTP/1.1
@@ -177,8 +177,8 @@ Content-Type: application/json
 Accept: application/json
 
 { "languages": [
-      { "language_id": "2" },
-      { "language_id": "3" }
+      { "language_id": 2 },
+      { "language_id": 3 }
    [
 }
 </pre>
@@ -194,17 +194,17 @@ Content-Type: application/json
 Accept: application/json
 
 { "languages": [
-      { "language_id": "1",
+      { "language_id": 1,
          "films": [
-            { "film_id": "3" },
-            { "film_id": "43" },
-            { "film_id": "67" }
+            { "film_id": 3 },
+            { "film_id": 43 },
+            { "film_id": 67 }
          ]
       },
-      { "language_id": "2" 
+      { "language_id": 2 
          "films": [
-            { "film_id": "3" },
-            { "film_id": "43" }
+            { "film_id": 3 },
+            { "film_id": 43 }
          ]
       }
    [
@@ -222,8 +222,8 @@ Content-Type: application/json
 Accept: application/json
 
 { "actors": [
-      { "actor_id": "123" },
-      { "actor_id": "124" }
+      { "actor_id": 123 },
+      { "actor_id": 124 }
    [
 }
 </pre>
@@ -231,7 +231,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "18" }</pre>
+{ "rowsAffected": 18 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResGetPath.html
+++ b/WebContent/doc/ref/ResGetPath.html
@@ -113,7 +113,7 @@ Accept: applicaton/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "id": "123", "first_name": "JULIANNE", "surname": "DENCH" }
+      { "id": 123, "first_name": "JULIANNE", "surname": "DENCH" }
    ]
 }
 </pre>
@@ -125,13 +125,13 @@ Accept: applicaton/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "id": "123", "first_name": "JULIANNE", "surname": "DENCH" },
+      { "id": 123, "first_name": "JULIANNE", "surname": "DENCH" },
          "films": [
-            { "year": "2006", "title": "ADAPTATION HOLES", "film_id": "3" },
-            { "year": "2006", "title": "ATLANTIS CAUSE", "film_id": "43" },
-            { "year": "2006", "title": "BERETS AGENT", "film_id": "67" },
-            { "year": "2006", "title": "BULL SHAWSHANK", "film_id": "105" },
-            { "year": "2006", "title": "CHOCOLATE DUCK", "film_id": "138" },
+            { "year": 2006, "title": "ADAPTATION HOLES", "film_id": 3 },
+            { "year": 2006, "title": "ATLANTIS CAUSE", "film_id": 43 },
+            { "year": 2006, "title": "BERETS AGENT", "film_id": 67 },
+            { "year": 2006, "title": "BULL SHAWSHANK", "film_id": 105 },
+            { "year": 2006, "title": "CHOCOLATE DUCK", "film_id": 138 },
          ]
       }
    ]

--- a/WebContent/doc/ref/ResGetQuery.html
+++ b/WebContent/doc/ref/ResGetQuery.html
@@ -173,7 +173,7 @@ Accept: application/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "actor_id": "123", "first_name": "JULIANNE", "surname": "DENCH" }
+      { "actor_id": 123, "first_name": "JULIANNE", "surname": "DENCH" }
    ]
 }
 </pre>
@@ -185,15 +185,15 @@ Accept: application/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "actor_id": "180", "first_name": "JEFF", "surname": "SILVERSTONE" },
-      { "actor_id": "195", "first_name": "JAYNE", "surname": "SILVERSTONE" }
-      { "actor_id": "78", "first_name": "GROUCHO", "surname": "SINATRA" },
-      { "actor_id": "31", "first_name": "SISSY", "surname": "SOBIESKI" },
-      { "actor_id": "44", "first_name": "NICK", "surname": "STALLONE" },
-      { "actor_id": "24", "first_name": "CAMERON", "surname": "STREEP" },
-      { "actor_id": "116", "first_name": "DAN", "surname": "STREEP" },
-      { "actor_id": "192", "first_name": "JOHN", "surname": "SUVARI" },
-      { "actor_id": "9", "first_name": "JOE", "surname": "SWANK" },
+      { "actor_id": 180, "first_name": "JEFF", "surname": "SILVERSTONE" },
+      { "actor_id": 195, "first_name": "JAYNE", "surname": "SILVERSTONE" }
+      { "actor_id": 78, "first_name": "GROUCHO", "surname": "SINATRA" },
+      { "actor_id": 31, "first_name": "SISSY", "surname": "SOBIESKI" },
+      { "actor_id": 44, "first_name": "NICK", "surname": "STALLONE" },
+      { "actor_id": 24, "first_name": "CAMERON", "surname": "STREEP" },
+      { "actor_id": 116, "first_name": "DAN", "surname": "STREEP" },
+      { "actor_id": 192, "first_name": "JOHN", "surname": "SUVARI" },
+      { "actor_id": 9, "first_name": "JOE", "surname": "SWANK" },
    ]
 }
 </pre>
@@ -205,16 +205,16 @@ Accept: application/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "actor_id": "1", "first_name": "PENELOPE", "surname": "GUINESS" },
-      { "actor_id": "2", "first_name": "NICK", "surname": "WAHLBERG" },
-      { "actor_id": "3", "first_name": "ED", "surname": "CHASE" },
-      { "actor_id": "4", "first_name": "JENNIFER", "surname": "DAVIS" },
-      { "actor_id": "5", "first_name": "JOHNNY", "surname": "LOLLOBRIGIDA" },
-      { "actor_id": "6", "first_name": "BETTE", "surname": "NICHOLSON" },
-      { "actor_id": "7", "first_name": "GRACE", "surname": "MOSTEL" },
-      { "actor_id": "8", "first_name": "MATTHEW", "surname": "JOHANSSON" },
-      { "actor_id": "9", "first_name": "JOE", "surname": "SWANK" },
-      { "actor_id": "10", "first_name": "CHRISTIAN", "surname": "GABLE" }
+      { "actor_id": 1, "first_name": "PENELOPE", "surname": "GUINESS" },
+      { "actor_id": 2, "first_name": "NICK", "surname": "WAHLBERG" },
+      { "actor_id": 3, "first_name": "ED", "surname": "CHASE" },
+      { "actor_id": 4, "first_name": "JENNIFER", "surname": "DAVIS" },
+      { "actor_id": 5, "first_name": "JOHNNY", "surname": "LOLLOBRIGIDA" },
+      { "actor_id": 6, "first_name": "BETTE", "surname": "NICHOLSON" },
+      { "actor_id": 7, "first_name": "GRACE", "surname": "MOSTEL" },
+      { "actor_id": 8, "first_name": "MATTHEW", "surname": "JOHANSSON" },
+      { "actor_id": 9, "first_name": "JOE", "surname": "SWANK" },
+      { "actor_id": 10, "first_name": "CHRISTIAN", "surname": "GABLE" }
    ]
 }
 </pre>
@@ -226,13 +226,13 @@ Accept: application/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "actor_id": "123", "first_name": "JULIANNE", "surname": "DENCH" },
+      { "actor_id": 123, "first_name": "JULIANNE", "surname": "DENCH" },
          "films": [
-            { "year": "2006", "title": "ADAPTATION HOLES", "film_id": "3" },
-            { "year": "2006", "title": "ATLANTIS CAUSE", "film_id": "43" },
-            { "year": "2006", "title": "BERETS AGENT", "film_id": "67" },
-            { "year": "2006", "title": "BULL SHAWSHANK", "film_id": "105" },
-            { "year": "2006", "title": "CHOCOLATE DUCK", "film_id": "138" },
+            { "year": 2006, "title": "ADAPTATION HOLES", "film_id": 3 },
+            { "year": 2006, "title": "ATLANTIS CAUSE", "film_id": 43 },
+            { "year": 2006, "title": "BERETS AGENT", "film_id": 67 },
+            { "year": 2006, "title": "BULL SHAWSHANK", "film_id": 105 },
+            { "year": 2006, "title": "CHOCOLATE DUCK", "film_id": 138 },
          ]
       }
    ]
@@ -246,11 +246,11 @@ Accept: application/json</pre>
 Content-Type: application/json
 
 { "actors": [
-      { "actor_id": "147", "first_name": "FAY", "surname": "WINSLET" },
-      { "actor_id": "156", "first_name": "FAY", "surname": "WOOD" },
-      { "actor_id": "164", "first_name": "HUMPHREY", "surname": "WILLIS" },
-      { "actor_id": "168", "first_name": "WILL", "surname": "WILSON" },
-      { "actor_id": "186", "first_name": "JULIA", "surname": "ZELLWEGER" }
+      { "actor_id": 147, "first_name": "FAY", "surname": "WINSLET" },
+      { "actor_id": 156, "first_name": "FAY", "surname": "WOOD" },
+      { "actor_id": 164, "first_name": "HUMPHREY", "surname": "WILLIS" },
+      { "actor_id": 168, "first_name": "WILL", "surname": "WILSON" },
+      { "actor_id": 186, "first_name": "JULIA", "surname": "ZELLWEGER" }
    ]
 }
 </pre>

--- a/WebContent/doc/ref/ResMediaTypes.html
+++ b/WebContent/doc/ref/ResMediaTypes.html
@@ -132,9 +132,9 @@ The attribute is named after the parent table's plural name (or alias), as in:
 </p>
 <pre>
 { "actors": [
-      { "id": "123", "first_name": "JULIANNE", "surname": "DENCH" },
-      { "id": "124", "first_name": "SCARLETT", "surname": "BENING" },
-      { "id": "125, "first_name": "ALBERT", "surname": "NOLTE" }
+      { "id": 123, "first_name": "JULIANNE", "surname": "DENCH" },
+      { "id": 124, "first_name": "SCARLETT", "surname": "BENING" },
+      { "id": 125, "first_name": "ALBERT", "surname": "NOLTE" }
    ]
 }
 </pre>
@@ -143,17 +143,17 @@ In a hiearchical SQL Resource, the object may contain two levels of elements, as
 </div>
 <pre>
 { "actors": [
-      { "actor_id": "123", "first_name": "JULIANNE", "surname": "DENCH" },
+      { "actor_id": 123, "first_name": "JULIANNE", "surname": "DENCH" },
          "films": [
-            { "year": "2006", "title": "ADAPTATION HOLES", "film_id": "3" },
-            { "year": "2006", "title": "ATLANTIS CAUSE", "film_id": "43" }
+            { "year": 2006, "title": "ADAPTATION HOLES", "film_id": 3 },
+            { "year": 2006, "title": "ATLANTIS CAUSE", "film_id": 43 }
          ]
       },
-      { "actor_id": "123", "first_name": "SCARLETT", "surname": "BENING" },
+      { "actor_id": 124, "first_name": "SCARLETT", "surname": "BENING" },
          "films": [
-            { "year": "2006", "title": "BERETS AGENT", "film_id": "67" },
-            { "year": "2006", "title": "BULL SHAWSHANK", "film_id": "105" },
-            { "year": "2006", "title": "CHOCOLATE DUCK", "film_id": "138" },
+            { "year": 2006, "title": "BERETS AGENT", "film_id": 67 },
+            { "year": 2006, "title": "BULL SHAWSHANK", "film_id": 105 },
+            { "year": 2006, "title": "CHOCOLATE DUCK", "film_id": 138 },
          ]
       }      
    ]
@@ -168,7 +168,8 @@ In a hiearchical SQL Resource, the object may contain two levels of elements, as
 <p class="text">Unlike XML, the JSON write request object is encoded the same as a read response object.</p>
 <p class="text">A write response cotains an object with a single attribute with the rows affected, as in:</p>
 <pre>
-{ "rowsAffected": "4" }</pre>
+{ "rowsAffected": 4 }</pre>
+<p class="text">Also unlike XML, the JSON responses support numeric types as well as string types.  Write requests will accept strings or numbers for numeric columns.</p>
 
 <h2>More References</h2>
 <div class="text">See the IETF RFC <a href="http://tools.ietf.org/html/rfc2616#page-100">HTTP Standard Headers</a>.</div>

--- a/WebContent/doc/ref/ResPostPathXmlOrJson.html
+++ b/WebContent/doc/ref/ResPostPathXmlOrJson.html
@@ -113,16 +113,16 @@ Content-Type: application/json
 Accept: application/json
 
 { "films": [
-      { "year": "2006", "title": "ADAPTATION HOLES", "film_id": "3" },
-      { "year": "2006", "title": "ATLANTIS CAUSE", "film_id": "43" },
-      { "year": "2006", "title": "BERETS AGENT", "film_id": "67" }
+      { "year": 2006, "title": "ADAPTATION HOLES", "film_id": 3 },
+      { "year": 2006, "title": "ATLANTIS CAUSE", "film_id": 43 },
+      { "year": 2006, "title": "BERETS AGENT", "film_id": 67 }
    ]
 }
 </pre>
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 
 <div class="text">A many-to-many hierarchical SQL resource (child rows are only associated to parent):</div>
 <pre>POST /restsql/res/ActorFilm/123 HTTP/1.1
@@ -130,16 +130,16 @@ Content-Type: application/json
 Accept: application/json
 
 { "films": [
-      { "film_id": "3" },
-      { "film_id": "43" },
-      { "film_id": "67" },
+      { "film_id": 3 },
+      { "film_id": 43 },
+      { "film_id": 67 },
    ]
 }
 </pre>
 <pre>HTTP/1.1 200 OK
 Content-Type: application/xml
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResPostUrlEnc.html
+++ b/WebContent/doc/ref/ResPostUrlEnc.html
@@ -96,7 +96,7 @@ actor_id=201&amp;first_name=JULIANNE&amp;last_name=DENCH
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "4" }</pre>
+{ "rowsAffected": 4 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResPostXmlOrJson.html
+++ b/WebContent/doc/ref/ResPostXmlOrJson.html
@@ -141,16 +141,16 @@ Content-Type: application/json
 Accept: application/json
 
 { "actors": [
-      { "id": "123", "first_name": "JULIANNE", "surname": "DENCH" },
-      { "id": "124", "first_name": "SCARLETT", "surname": "BENING" },
-      { "id": "125", "first_name": "ALBERT", "surname": "NOLTE" }
+      { "id": 123, "first_name": "JULIANNE", "surname": "DENCH" },
+      { "id": 124, "first_name": "SCARLETT", "surname": "BENING" },
+      { "id": 125, "first_name": "ALBERT", "surname": "NOLTE" }
    ]
 }
 </pre>
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 
 <p class="text">An insert to parents of a hierarchical SQL Resource would look identical to the proceeding.</p>
 
@@ -160,14 +160,14 @@ Content-Type: application/json
 Accept: application/json
 
 { "languages": [
-      { "language_id": "1",
+      { "language_id": 1,
          "films": [
-            { "year": "2006", "title": "ADAPTATION HOLES", "film_id": "3" },
-            { "year": "2006", "title": "ATLANTIS CAUSE", "film_id": "43" },
-            { "year": "2006", "title": "BERETS AGENT", "film_id": "67" }
+            { "year": 2006, "title": "ADAPTATION HOLES", "film_id": 3 },
+            { "year": 2006, "title": "ATLANTIS CAUSE", "film_id": 43 },
+            { "year": 2006, "title": "BERETS AGENT", "film_id": 67 }
          ]
       },
-      { "language_id": "4", "langName": "Quechua" }
+      { "language_id": 4, "langName": "Quechua" }
    ]   
 }
 </pre>
@@ -183,14 +183,14 @@ Content-Type: application/json
 Accept: application/json
 
 { "actors": [
-      { "actor_id": "123",
+      { "actor_id": 123,
          "films": [
-            { "film_id": "3" },
-            { "film_id": "43" },
-            { "film_id": "67" },
+            { "film_id": 3 },
+            { "film_id": 43 },
+            { "film_id": 67 },
          ]
       },
-      { "actor_id": "124", "first_name": "BENITO", last_name="BENINGS" }
+      { "actor_id": 124, "first_name": "BENITO", last_name="BENINGS" }
    ]   
 }
 </pre>
@@ -198,7 +198,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "4" }</pre>
+{ "rowsAffected": 4 }</pre>
 
 </div>
 </body>

--- a/WebContent/doc/ref/ResPutPathUrlEnc.html
+++ b/WebContent/doc/ref/ResPutPathUrlEnc.html
@@ -96,7 +96,7 @@ first_name=JULIANNER&amp;last_name=DENCHY
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "1" }</pre>
+{ "rowsAffected": 1 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResPutPathXmlOrJson.html
+++ b/WebContent/doc/ref/ResPutPathXmlOrJson.html
@@ -106,7 +106,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResPutQueryUrlEnc.html
+++ b/WebContent/doc/ref/ResPutQueryUrlEnc.html
@@ -97,7 +97,7 @@ rating=R&amp;rental_duration=2
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 </div>
 </body>
 </html>

--- a/WebContent/doc/ref/ResPutXmlOrJson.html
+++ b/WebContent/doc/ref/ResPutXmlOrJson.html
@@ -131,7 +131,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "3" }</pre>
+{ "rowsAffected": 3 }</pre>
 <p class="text">An update to parents of a hierarchical SQL Resource would look identical to the proceeding.</p>
 
 <div class="text">An update to children of one parent and another parent for a hierarchical SQL Resource:</div>
@@ -155,7 +155,7 @@ Accept: application/json
 <pre>HTTP/1.1 200 OK
 Content-Type: application/json
 
-{ "rowsAffected": "4" }</pre>
+{ "rowsAffected": 4 }</pre>
 </div>
 </body>
 </html>


### PR DESCRIPTION
I updated most of the json requests to have real numbers for numeric columns, and all the json responses.  I also left some of the json requests with strings for numeric columns, and noted that that would still work in the documentation.
